### PR TITLE
Rework palette to a low-chroma silver system

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "tsar"
 name = "TSAR Theme"
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["x <x032205@gmail.com>"]
 description = "Minimal and modern semi-transparent dark theme."

--- a/themes/tsar.json
+++ b/themes/tsar.json
@@ -53,199 +53,319 @@
         "scrollbar.thumb.border": null,
         "scrollbar.track.background": "#09090B50",
         "scrollbar.track.border": null,
-        "editor.foreground": "#FFFFFF",
+        "editor.foreground": "#E4E4E7",
         "editor.background": "#09090B80",
         "editor.gutter.background": "#09090B80",
         "editor.subheader.background": null,
         "editor.active_line.background": "#FFFFFF10",
         "editor.highlighted_line.background": null,
-        "editor.line_number": "#A1A1AA",
+        "editor.line_number": "#52525B",
         "editor.active_line_number": "#FFFFFF",
-        "editor.invisible": null,
+        "editor.invisible": "#3F3F46",
         "editor.wrap_guide": "#3A3A3A",
         "editor.active_wrap_guide": "#3A3A3A",
         "editor.document_highlight.read_background": null,
         "editor.document_highlight.write_background": null,
         "terminal.background": "#09090B30",
-        "terminal.foreground": null,
-        "terminal.bright_foreground": null,
-        "terminal.dim_foreground": null,
-        "terminal.ansi.black": "#E8E4CF",
-        "terminal.ansi.bright_black": "#57564F",
-        "terminal.ansi.dim_black": null,
-        "terminal.ansi.red": "#A8473B",
-        "terminal.ansi.bright_red": "#DD6F61",
-        "terminal.ansi.dim_red": null,
-        "terminal.ansi.green": "#76BA53",
-        "terminal.ansi.bright_green": "#9DE478",
-        "terminal.ansi.dim_green": null,
-        "terminal.ansi.yellow": "#E1D797",
-        "terminal.ansi.bright_yellow": "#857F5C",
-        "terminal.ansi.dim_yellow": null,
-        "terminal.ansi.blue": "#3D6EB6",
-        "terminal.ansi.bright_blue": "#81A9F6",
-        "terminal.ansi.dim_blue": null,
-        "terminal.ansi.magenta": "#AE30C2",
-        "terminal.ansi.bright_magenta": "#D86DE9",
-        "terminal.ansi.dim_magenta": null,
-        "terminal.ansi.cyan": "#3DB6B0",
-        "terminal.ansi.bright_cyan": "#5BDFD8",
-        "terminal.ansi.dim_cyan": null,
-        "terminal.ansi.white": "#131313",
-        "terminal.ansi.bright_white": "#3A3A3A",
-        "terminal.ansi.dim_white": null,
+        "terminal.foreground": "#E4E4E7",
+        "terminal.bright_foreground": "#FFFFFF",
+        "terminal.dim_foreground": "#A1A1AA",
+        "terminal.ansi.black": "#3F3F46",
+        "terminal.ansi.bright_black": "#5F5F68",
+        "terminal.ansi.dim_black": "#2A2A30",
+        "terminal.ansi.red": "#C9A5A5",
+        "terminal.ansi.bright_red": "#DFC0C0",
+        "terminal.ansi.dim_red": "#8E7676",
+        "terminal.ansi.green": "#A9C4A0",
+        "terminal.ansi.bright_green": "#C6DCBE",
+        "terminal.ansi.dim_green": "#788A72",
+        "terminal.ansi.yellow": "#CBC3A2",
+        "terminal.ansi.bright_yellow": "#E2DCC0",
+        "terminal.ansi.dim_yellow": "#8F8A73",
+        "terminal.ansi.blue": "#A2B3CE",
+        "terminal.ansi.bright_blue": "#C3CFE2",
+        "terminal.ansi.dim_blue": "#737E91",
+        "terminal.ansi.magenta": "#BFA5C9",
+        "terminal.ansi.bright_magenta": "#D8C4E0",
+        "terminal.ansi.dim_magenta": "#87768E",
+        "terminal.ansi.cyan": "#A0C4C2",
+        "terminal.ansi.bright_cyan": "#C2DEDC",
+        "terminal.ansi.dim_cyan": "#728A89",
+        "terminal.ansi.white": "#D4D4D8",
+        "terminal.ansi.bright_white": "#F4F4F5",
+        "terminal.ansi.dim_white": "#95959B",
         "link_text.hover": null,
-        "conflict": "#f87171",
-        "conflict.background": null,
-        "conflict.border": null,
-        "created": null,
-        "created.background": null,
-        "created.border": null,
-        "deleted": "#fb923c",
-        "deleted.background": null,
-        "deleted.border": null,
-        "error": null,
-        "error.background": "#46190CF0",
-        "error.border": "#802207",
-        "hidden": "#9E9E9E",
+        "conflict": "#C7ADA0",
+        "conflict.background": "#2A211CF0",
+        "conflict.border": "#6B5A4A",
+        "created": "#A9C4A0",
+        "created.background": "#1C241C80",
+        "created.border": "#4A5A4A",
+        "deleted": "#C9A5A5",
+        "deleted.background": "#241C1C80",
+        "deleted.border": "#5A4A4A",
+        "error": "#CE9E9E",
+        "error.background": "#2A1C1CF0",
+        "error.border": "#6B4A4A",
+        "hidden": "#71717A",
         "hidden.background": null,
         "hidden.border": null,
-        "hint": null,
+        "hint": "#71717A",
         "hint.background": null,
         "hint.border": "#27272A",
-        "ignored": "#3A3A3A",
+        "ignored": "#52525B",
         "ignored.background": null,
         "ignored.border": null,
-        "info": null,
+        "info": "#A2B3CE",
         "info.background": null,
         "info.border": "#27272A",
-        "modified": "#B0A878",
-        "modified.background": null,
-        "modified.border": null,
-        "predictive": "#5D5945",
+        "modified": "#CBC3A2",
+        "modified.background": "#24231A80",
+        "modified.border": "#5A5747",
+        "predictive": "#5F5F68",
         "predictive.background": null,
         "predictive.border": null,
-        "renamed": null,
+        "renamed": "#A2B3CE",
         "renamed.background": null,
         "renamed.border": null,
-        "success": null,
+        "success": "#A9C4A0",
         "success.background": null,
         "success.border": null,
-        "unreachable": null,
+        "unreachable": "#71717A",
         "unreachable.background": null,
         "unreachable.border": null,
-        "warning": null,
-        "warning.background": "#3A310EF0",
-        "warning.border": "#7B6508",
+        "warning": "#CEC49E",
+        "warning.background": "#2A281AF0",
+        "warning.border": "#6B6450",
         "players": [],
         "syntax": {
           "attribute": {
-            "color": "#be9a52",
+            "color": "#9FAFC2",
             "font_style": null,
             "font_weight": null
           },
           "boolean": {
-            "color": "#0AC3EC",
+            "color": "#EAE0CB",
             "font_style": null,
             "font_weight": null
           },
           "comment": {
-            "color": "#A1A1AA",
-            "font_style": null,
+            "color": "#71717A",
+            "font_style": "italic",
             "font_weight": null
           },
           "comment.doc": {
-            "color": "#A1A1AA",
-            "font_style": null,
+            "color": "#7D7D86",
+            "font_style": "italic",
             "font_weight": null
           },
           "constant": {
-            "color": "#0AC3EC",
+            "color": "#EAE0CB",
             "font_style": null,
             "font_weight": null
           },
           "constructor": {
-            "color": "#b5af9a",
+            "color": "#D0D9E4",
             "font_style": null,
             "font_weight": null
           },
           "embedded": {
-            "color": "#CACCCA",
+            "color": "#E4E4E7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#E4E4E7",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#FFFFFF",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#D0D9E4",
             "font_style": null,
             "font_weight": null
           },
           "function": {
-            "color": "#f87171",
+            "color": "#FFFFFF",
+            "font_style": null,
+            "font_weight": 600
+          },
+          "function.builtin": {
+            "color": "#FFFFFF",
+            "font_style": null,
+            "font_weight": 600
+          },
+          "function.definition": {
+            "color": "#FFFFFF",
+            "font_style": null,
+            "font_weight": 600
+          },
+          "function.method": {
+            "color": "#FFFFFF",
+            "font_style": null,
+            "font_weight": 600
+          },
+          "hint": {
+            "color": "#71717A",
             "font_style": null,
             "font_weight": null
           },
           "keyword": {
-            "color": "#0AC3EC",
+            "color": "#A1A1AA",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#B5C4D6",
             "font_style": null,
             "font_weight": null
           },
           "link_text": {
-            "color": "#A86D3B",
+            "color": "#D0D9E4",
             "font_style": "normal",
             "font_weight": null
           },
           "link_uri": {
-            "color": "#6F6D66",
+            "color": "#8A8A93",
             "font_style": "italic",
             "font_weight": null
           },
+          "namespace": {
+            "color": "#B5C4D6",
+            "font_style": null,
+            "font_weight": null
+          },
           "number": {
-            "color": "#E19773",
+            "color": "#EAE0CB",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#8A8A93",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#5F5F68",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#C8BFB0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#E4E4E7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#CDCDD3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#8A8A93",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#7A7A84",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#7A7A84",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#A1A1AA",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#A1A1AA",
             "font_style": null,
             "font_weight": null
           },
           "string": {
-            "color": "#0ADD9E",
+            "color": "#D3CBBB",
             "font_style": null,
             "font_weight": null
           },
           "string.escape": {
-            "color": "#76BA53",
+            "color": "#F5EDDD",
             "font_style": null,
             "font_weight": null
           },
           "string.regex": {
-            "color": "#76BA53",
+            "color": "#F5EDDD",
             "font_style": null,
             "font_weight": null
           },
           "string.special": {
-            "color": "#E1D797",
+            "color": "#EAE0CB",
             "font_style": null,
             "font_weight": null
           },
           "string.special.symbol": {
-            "color": "#E1D797",
+            "color": "#EAE0CB",
             "font_style": null,
             "font_weight": null
           },
           "tag": {
-            "color": "#60a5fa",
+            "color": "#B5C4D6",
             "font_style": null,
             "font_weight": null
           },
           "text.literal": {
-            "color": "#E1D797",
+            "color": "#D3CBBB",
             "font_style": null,
             "font_weight": null
           },
           "title": {
-            "color": "#A76D3B",
+            "color": "#FFFFFF",
             "font_style": null,
             "font_weight": 600
           },
           "type": {
-            "color": "#f87171",
+            "color": "#D0D9E4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#D0D9E4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#E4E4E7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#CDCDD3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#C6CDD8",
             "font_style": null,
             "font_weight": null
           },
           "variable.special": {
-            "color": "#E19773",
+            "color": "#B3BECC",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#EAE0CB",
             "font_style": null,
             "font_weight": null
           }


### PR DESCRIPTION
Pivots TSAR from a saturated palette to a near-grayscale silver one, and fixes a fallback bug that was leaving most of the editor pure white.

## The white-token bug

The theme defined **22** syntax capture keys. Zed resolves a capture by walking from the most specific name down, and anything with no match lands on `editor.foreground` — which was `#FFFFFF`. So `enum`, `variable`, `property`, `operator`, and `punctuation` were all undefined and rendering flat white. That is most of a typical file; the 22 colors that did work were the minority.

Now **46** keys are defined, and `editor.foreground` drops to `#E4E4E7` so any capture still not covered lands on silver instead of white.

## The palette

With hue no longer carrying meaning, distinctions come from lightness tier, a faint warm/cool tint, and weight:

| tier | tokens | color |
|---|---|---|
| anchors, weight 600 | function, method, title | `#FFFFFF` |
| identifiers | variable, embedded | `#E4E4E7` |
| | property, member | `#CDCDD3` |
| | parameter | `#C6CDD8` |
| types, cool tint | type, enum, constructor | `#D0D9E4` |
| | tag, namespace, label | `#B5C4D6` |
| | attribute | `#9FAFC2` |
| literals, warm tint | number, boolean, constant, enum variant | `#EAE0CB` |
| | string | `#D3CBBB` |
| | escape, regex | `#F5EDDD` |
| scaffolding | keyword | `#A1A1AA` |
| | operator, punctuation | `#8A8A93` |
| | brackets, delimiters | `#7A7A84` |
| receding | comment, italic | `#71717A` |
| | predictive ghost text | `#5F5F68` |

Max chroma across the syntax palette is **14%**, mean **6%** (0% is pure gray). Contrast runs 19.9:1 down to 4.1:1 for comments, with only `predictive` lower at 3.1:1, which is intended for ghost text.

An enum *type* is cool and its *members* are warm, so `Status.Active` still splits into type and value without a saturated color.

## Terminal ANSI

All 16 colors plus the dim variants, retinted to ~14% chroma. Two bugs fixed along the way:

- `ansi.black` was `#E8E4CF` (light cream) and `ansi.white` was `#131313` (near black) — inverted. Anything printing ANSI white was effectively invisible against the background.
- All six `dim_*` slots and `terminal.foreground` were `null`, falling back to Zed defaults unrelated to this theme.

## Diff and diagnostics

`created` was unset (so Zed's default green) and `deleted` was `#fb923c`, which produced the orange slab behind removed lines. These keep their hue *direction* at ~15% chroma rather than going flat gray, because a diff where added and removed read identically is unusable. The `.background` and `.border` variants are now set explicitly instead of `null`.

`error` and `warning` are muted but given slightly more chroma (19%) than everything else, on the reasoning that a diagnostic you do not notice is worse than a slightly loud one.

## Notes

- Two stylistic choices that are one-line reverts: functions are weight 600, comments are italic. With hue gone, weight and slant are what is left to separate them.
- Version bumped `0.0.3` → `0.0.4`, matching the existing patch cadence. Given the scale of the visual change, `0.1.0` may be more honest.
- **`assets/preview.png` is now stale** — it still shows the old saturated palette and should be regenerated before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)